### PR TITLE
Move unified view into a bottom panel, accessible by a status bar button

### DIFF
--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -137,10 +137,6 @@ module.exports = PhpDebug =
       if @currentCodePointDecoration
         @currentCodePointDecoration.destroy()
 
-    @GlobalContext.onRunning () =>
-      if @currentBreakDecoration
-        @currentBreakDecoration.destroy()
-
     @GlobalContext.onWatchpointsChange () =>
       if @GlobalContext.getCurrentDebugContext()
         @GlobalContext.getCurrentDebugContext().syncCurrentContext(0)
@@ -256,9 +252,6 @@ module.exports = PhpDebug =
   toggleDebugging: ->
     if @currentCodePointDecoration
       @currentCodePointDecoration.destroy()
-
-    if @currentBreakDecoration
-      @currentBreakDecoration.destroy()
 
     if @settingsView
       @settingsView.close()

--- a/lib/status/php-debug-status-view.coffee
+++ b/lib/status/php-debug-status-view.coffee
@@ -1,0 +1,20 @@
+{$, View} = require 'atom-space-pen-views'
+module.exports =
+class PhpDebugStatusView extends View
+  @content: ->
+    @div click: 'toggleDebugging', class: 'php-debug-status-view', =>
+      @span class: 'icon icon-bug'
+      @text('PHP Debug')
+
+  constructor: (statusBar, @phpDebug) ->
+    super
+    statusBar.addLeftTile(item: @element, priority: -100)
+
+  toggleDebugging: ->
+    @phpDebug.toggleDebugging()
+
+  setActive: (active) ->
+    if active
+      @element.className = 'php-debug-status-view active'
+    else
+      @element.className = 'php-debug-status-view'

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -46,6 +46,9 @@ class PhpDebugUnifiedView extends ScrollView
           target.style.width  = event.rect.width + 'px'
           target.style.height = event.rect.height + 'px'
       )
+      .on('resizeend', (event) ->
+        event.target.style.width = 'auto'
+      )
 
     @setConnected(false)
 

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -4,21 +4,25 @@ PhpDebugContextView = require '../context/php-debug-context-view'
 PhpDebugStackView = require '../stack/php-debug-stack-view'
 PhpDebugWatchView = require '../watch/php-debug-watch-view'
 PhpDebugBreakpointView = require '../breakpoint/php-debug-breakpoint-view'
+Interact = require('interact.js')
 module.exports =
 class PhpDebugUnifiedView extends ScrollView
   @content: ->
-    @div class: 'php-debug php-debug-unified-view pane-item padded', style: 'overflow:auto;', tabindex: -1, =>
-      @div class: "block", =>
-        @button class: "btn octicon icon-playback-play inline-block-tight",    disabled: 'disabled', 'data-action':'continue', "Continue"
-        @button class: "btn octicon icon-steps inline-block-tight",            disabled: 'disabled', 'data-action':'step', "Step Over"
-        @button class: "btn octicon icon-sign-in inline-block-tight",          disabled: 'disabled', 'data-action':'in', "Step In"
-        @button class: "btn octicon icon-sign-out inline-block-tight",         disabled: 'disabled', 'data-action':'out', "Step Out"
-        @button class: "btn octicon icon-primitive-square inline-block-tight", disabled: 'disabled', 'data-action':'stop', "Stop"
-      @div class: 'tabs-view', =>
-        @div outlet: 'stackView', class:'php-debug-tab'
-        @div outlet: 'contextView', class:'php-debug-tab'
-        @div outlet: 'watchpointView', class:'php-debug-tab'
-        @div outlet: 'breakpointView', class:'php-debug-tab'
+    @div class: 'php-debug php-debug-unified-view', style: 'overflow:auto;', tabindex: -1, =>
+      @div class: 'php-debug-resize-handle'
+      @div class: 'padded', =>
+        @div class: 'block', =>
+          @button class: "btn octicon icon-playback-play inline-block-tight",    disabled: 'disabled', 'data-action':'continue', "Continue"
+          @button class: "btn octicon icon-steps inline-block-tight",            disabled: 'disabled', 'data-action':'step', "Step Over"
+          @button class: "btn octicon icon-sign-in inline-block-tight",          disabled: 'disabled', 'data-action':'in', "Step In"
+          @button class: "btn octicon icon-sign-out inline-block-tight",         disabled: 'disabled', 'data-action':'out', "Step Out"
+          @button class: "btn octicon icon-primitive-square inline-block-tight", disabled: 'disabled', 'data-action':'stop', "Stop"
+          @span outlet: 'connectStatus'
+        @div class: 'tabs-view', =>
+          @div outlet: 'stackView', class:'php-debug-tab'
+          @div outlet: 'contextView', class:'php-debug-tab'
+          @div outlet: 'watchpointView', class:'php-debug-tab'
+          @div outlet: 'breakpointView', class:'php-debug-tab'
 
   constructor: (params) ->
     super
@@ -31,6 +35,24 @@ class PhpDebugUnifiedView extends ScrollView
     @GlobalContext.onSessionEnd () =>
       @find('button').disable()
 
+    Interact(this.element).resizable({edges: { top: true }})
+      .on('resizemove', (event) ->
+        target = event.target
+        if event.rect.height < 25
+          if event.rect.height < 1
+            target.style.width = target.style.height = null
+          else
+            return # No-Op
+        else
+          target.style.width  = event.rect.width + 'px'
+          target.style.height = event.rect.height + 'px'
+      )
+
+    @setConnected(false)
+
+    @visible = false
+    @panel = atom.workspace.addBottomPanel({item: this.element, visible: @visible, priority: 400})
+
   serialize: ->
     deserializer: @constructor.name
     uri: @getURI()
@@ -38,6 +60,22 @@ class PhpDebugUnifiedView extends ScrollView
   getURI: -> @uri
 
   getTitle: -> "Debugging"
+
+  setConnected: (isConnected) =>
+    if isConnected
+      @connectStatus.text('Connected')
+    else
+      serverPort = atom.config.get('php-debug.ServerPort')
+      @connectStatus.text("Listening on port #{serverPort}...")
+
+  setVisible: (@visible) =>
+    if @visible
+      @panel.show()
+    else
+      @panel.hide()
+
+  isVisible: () =>
+    @visible
 
   initialize: (params) =>
     super

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -8,9 +8,8 @@ Interact = require('interact.js')
 module.exports =
 class PhpDebugUnifiedView extends ScrollView
   @content: ->
-    @div class: 'php-debug php-debug-unified-view', style: 'overflow:auto;', tabindex: -1, =>
-      @div class: 'php-debug-resize-handle'
-      @div class: 'padded', =>
+    @div class: 'php-debug', tabindex: -1, =>
+      @div class: 'php-debug-unified-view', =>
         @div class: 'block', =>
           @button class: "btn octicon icon-playback-play inline-block-tight",    disabled: 'disabled', 'data-action':'continue', "Continue"
           @button class: "btn octicon icon-steps inline-block-tight",            disabled: 'disabled', 'data-action':'step', "Step Over"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
     "xml2js": ">= 0.4.6 < 0.5",
     "atom-space-pen-views": "^2.0.3",
     "event-kit": "^1.0.3",
-    "q": "^1.1.2"
+    "q": "^1.1.2",
+    "interact.js": "^1.2.5"
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^1.0.0": "consumeStatusBar"
+      }
+    }
   }
 }

--- a/styles/php-debug.atom-text-editor.less
+++ b/styles/php-debug.atom-text-editor.less
@@ -18,11 +18,12 @@
   background-color: fade(@background-color-error,15%) !important;
 }
 
-.php-debug-resize-handle {
-  width: 100%;
-  height: 8px;
-  margin-top: -4px;
-  cursor: row-resize;
+.php-debug {
+  overflow: auto;
+}
+
+.php-debug-unified-view {
+  margin: 10px;
 }
 
 .php-debug-status-view {

--- a/styles/php-debug.atom-text-editor.less
+++ b/styles/php-debug.atom-text-editor.less
@@ -17,3 +17,31 @@
 .debug-break-error {
   background-color: fade(@background-color-error,15%) !important;
 }
+
+.php-debug-resize-handle {
+  width: 100%;
+  height: 8px;
+  margin-top: -4px;
+  cursor: row-resize;
+}
+
+.php-debug-status-view {
+  display: inline-block;
+  color: @text-color-subtle;
+  border: 1px solid @button-border-color;
+  background: fade(@button-background-color, 33%);
+  cursor: pointer;
+  vertical-align: middle;
+  position: relative;
+  padding: 0 .6em;
+  line-height: 1.8em;
+  margin-right: 0.6em;
+
+  &:active {
+    background: transparent;
+  }
+  &.active {
+    color: @text-color-highlight;
+    background: @button-background-color;
+  }
+}


### PR DESCRIPTION
Hello!

I have been finding the interface with the split down very frustrating. Especially during debugging, as it can cause breakpoints to open the file inside the same panel as the Debugger, hiding the Debugger tab. To that end I took some inspiration from Linter, as I really like the way the linter uses a docked panel and a status bar icon.

This PR moves the unified view into a bottom panel and allows you to quickly toggle it with a status bar button. The panel is resizable (but doesn't yet remember the size.)

I also added a quick "Listening on port XXXX..." that turns into "Connected" when the debugger connects, so it's easier to see if things are working are not - otherwise, if you don't configure maps correctly, it almost looks like nothing is working (when really it is because its not finding the breakpoints due to maps.)

![screen shot 2015-11-18 at 13 55 56](https://cloud.githubusercontent.com/assets/939815/11242821/215888e6-8dfc-11e5-8a95-3ae1adfdedbd.png)

I realise it is a fairly chunky PR, but I hope to hear your thoughts on this, as in my opinion it greatly increases usability. Any changes or cleanups required I'm happy to make.