### PR TITLE
new error message pane and some fixes for package reloading

### DIFF
--- a/extras/example.php
+++ b/extras/example.php
@@ -8,6 +8,10 @@
   ##    - if you have debug.remote_autostart set to true, it should just work
   ##    - otherwise, use an xdebug browser extension to start the script with xdebug enabled
   ##    - or,
+
+  trigger_error("Error Test", E_USER_NOTICE);
+  trigger_error("Error Test", E_USER_WARNING);
+
   xdebug_break();
   $i = 1;
 

--- a/lib/context/context-variable-list-view.coffee
+++ b/lib/context/context-variable-list-view.coffee
@@ -25,5 +25,3 @@ class ContextVariableListView extends View
     if @variables
       for variable in @variables
         @contextVariableList.append(new ContextVariableView({variable:variable, parent: path,openpaths:@openpaths}))
-
-    

--- a/lib/engines/dbgp/dbgp-instance.coffee
+++ b/lib/engines/dbgp/dbgp-instance.coffee
@@ -206,7 +206,6 @@ class DbgpInstance extends DebugContext
             messages = response["xdebug:message"]
             message = messages[0]
             thing = message.$
-            #console.dir data
             filepath = decodeURI(thing['filename']).replace("file:///", "")
 
             if not filepath.match(/^[a-zA-Z]:/)
@@ -216,7 +215,7 @@ class DbgpInstance extends DebugContext
             type = 'break'
             if thing.exception
               type = "error"
-            breakpoint = new Breakpoint(filepath: filepath, line:lineno, type: type)
+            breakpoint = new Breakpoint(filepath: filepath, line:lineno, type: type, exception: thing.exception, message: message._)
             @GlobalContext.notifyBreak(breakpoint)
           when 'stopping'
             @executeStop()

--- a/lib/engines/dbgp/dbgp.coffee
+++ b/lib/engines/dbgp/dbgp.coffee
@@ -43,7 +43,7 @@ class Dbgp
         @close()
         @GlobalContext.notifySocketError()
         return false
-        
+
       @server?.listen @serverPort
       return true
     catch e

--- a/lib/error/php-debug-errormessage-view.coffee
+++ b/lib/error/php-debug-errormessage-view.coffee
@@ -1,0 +1,28 @@
+{View, $$} = require 'atom-space-pen-views'
+
+errorMap = (text) ->
+  text.slice(0,
+    if ~text.indexOf(' ') then text.indexOf(' ') else text.length
+  ).toLowerCase()
+
+
+module.exports =
+class PhpDebugErrormessageView extends View
+
+  @content: ->
+    @div class: 'php-debug php-debug-errormessage-view pane-item', =>
+      @div class: 'panel-heading', 'Error Message'
+      @div outlet: 'errorMessage', class: 'panel-content'
+
+  initialize: (params) ->
+    @GlobalContext = params.context
+    @GlobalContext.onBreak @showErrorType
+    @GlobalContext.onSessionEnd () => @errorMessage.empty()
+
+  showErrorType: (data) =>
+    @errorMessage.empty()
+    if !data.exception then return
+    @errorMessage.append $$ ->
+      @li =>
+        @div class: errorMap(data.exception), data.exception
+        @span data.message

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -14,7 +14,7 @@ exports.escapeValue = (object) ->
   if (typeof object == "string")
     return "\"" + object.replace("\\","\\\\").replace("\"","\\\"") + "\""
   return object;
-  
+
 exports.escapeHtml = (string) ->
   entityMap = {
     "<": "&lt;"
@@ -94,5 +94,5 @@ exports.remotePathToLocal = (remotePath) ->
       if remotePath.indexOf(remote) == 0
         return remotePath.replace(remote, local)
         break
-    
+
   return remotePath.replace('file://','')

--- a/lib/models/breakpoint-marker.coffee
+++ b/lib/models/breakpoint-marker.coffee
@@ -8,24 +8,24 @@ class BreakpointMarker
     if enableGutters && gutter
       gutterMarker = @editor.markBufferRange(@range, {invalidate: 'inside'})
       @markers.gutter = gutterMarker
-    
+
     lineMarker = @editor.markBufferRange(@range)
-    @markers.line = lineMarker 
-    
+    @markers.line = lineMarker
+
   decorate: ->
     item = document.createElement('span')
     item.className = "highlight php-debug-gutter php-debug-highlight"
 
     if @markers.gutter
       @gutter.decorateMarker(@markers.gutter, {class: 'php-debug-gutter-marker',item})
-    
+
     if @markers.line
       @editor.decorateMarker(@markers.line, {type: 'line-number', class: 'php-debug-breakpoint'})
-    
+
   destroy: ->
     for type,marker of @markers
       marker?.destroy()
-      
+
   getStartBufferPosition: ->
     for type,marker of @markers
       if marker

--- a/lib/models/breakpoint.coffee
+++ b/lib/models/breakpoint.coffee
@@ -16,7 +16,7 @@ class Breakpoint extends Codepoint
   @getNextBreakpointSettingId: () ->
     return @breakpointSettingId++
 
-  constructor: ({filepath, marker, line, @type, @exception, @settings}) ->
+  constructor: ({filepath, marker, line, @type, @exception, @message, @settings}) ->
     super
     if !@type
       @type =  Breakpoint.TYPE_LINE

--- a/lib/models/global-context.coffee
+++ b/lib/models/global-context.coffee
@@ -133,7 +133,7 @@ class GlobalContext
 
   notifySessionEnd: (data) ->
     @emitter.emit 'php-debug.sessionEnd', data
-    
+
   onSocketError: (callback) ->
     @emitter.on 'php-debug.socketError', callback
 

--- a/lib/php-debug-panel-view.coffee
+++ b/lib/php-debug-panel-view.coffee
@@ -5,4 +5,4 @@ class PhpDebugPanel extends View
   @content: ->
     @div class: "php-debug panel", =>
       @div class: "panel-heading", "Node Debugger"
-      @div class: "panel-body padded" 
+      @div class: "panel-body padded"

--- a/lib/php-debug-panel-view.coffee
+++ b/lib/php-debug-panel-view.coffee
@@ -1,8 +1,0 @@
-{View} = require 'atom'
-
-module.exports =
-class PhpDebugPanel extends View
-  @content: ->
-    @div class: "php-debug panel", =>
-      @div class: "panel-heading", "Node Debugger"
-      @div class: "panel-body padded"

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -225,7 +225,6 @@ module.exports = PhpDebug =
   deactivate: ->
     @unifiedView?.setConnected(false)
     @statusView?.destroy()
-    @statusView = null
     @unifiedView?.destroy()
     @subscriptions.dispose()
     @dbgp?.close()

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -224,7 +224,7 @@ module.exports = PhpDebug =
 
   deactivate: ->
     @unifiedView?.setConnected(false)
-    @statusView?.destroy()
+    @statusView?.remove()
     @unifiedView?.destroy()
     @subscriptions.dispose()
     @dbgp?.close()

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -136,7 +136,7 @@ module.exports = PhpDebug =
 
     @GlobalContext.onStackChange (codepoint) =>
       @doCodePoint(codepoint)
-    
+
     @GlobalContext.onSocketError () =>
       @toggleDebugging()
 
@@ -167,19 +167,19 @@ module.exports = PhpDebug =
         for breakpoint in event.removed
           if breakpoint.getMarker()
             breakpoint.getMarker().destroy()
-            
+
     atom.workspace.observeTextEditors (editor) =>
       if (atom.config.get('php-debug.GutterBreakpointToggle'))
         @createGutter editor
-      else 
+      else
         for breakpoint in @GlobalContext.getBreakpoints()
           if breakpoint.getPath() == editor.getPath()
             marker = @addBreakpointMarker(breakpoint.getLine(), editor)
             breakpoint.setMarker(marker)
-            
+
     atom.config.observe "php-debug.GutterBreakpointToggle", (newValue) =>
-      @createGutters newValue    
-        
+      @createGutters newValue
+
     atom.config.observe "php-debug.GutterPosition", (newValue) =>
       @createGutters atom.config.get('php-debug.GutterBreakpointToggle'),true
 
@@ -237,7 +237,7 @@ module.exports = PhpDebug =
       filepath = point.getPath()
 
       filepath = helpers.remotePathToLocal(filepath)
-      
+
       atom.workspace.open(filepath,{searchAllPanes: true, activatePane:true}).then (editor) =>
         if @currentCodePointDecoration
           @currentCodePointDecoration.destroy()
@@ -253,12 +253,12 @@ module.exports = PhpDebug =
   addBreakpointMarker: (line, editor) ->
     gutter = editor.gutterWithName("php-debug-gutter")
     range = [[line-1, 0], [line-1, 0]]
-    
+
     marker = new BreakpointMarker(editor,range,gutter)
     marker.decorate()
 
     return marker
-    
+
 
   breakpointSettings: ->
     BreakpointSettingsView = require './breakpoint/breakpoint-settings-view'
@@ -273,7 +273,7 @@ module.exports = PhpDebug =
         break
     @settingsView = new BreakpointSettingsView({breakpoint:breakpoint,context:@GlobalContext})
     @settingsView.attach()
-  
+
   createGutters: (create,recreate) ->
     editors = atom.workspace.getTextEditors()
     for editor in editors
@@ -289,29 +289,29 @@ module.exports = PhpDebug =
               gutter?.destroy()
           if (editor?.gutterWithName('php-debug-gutter') == null)
             @createGutter(editor)
-  
+
   createGutter: (editor) ->
     if (!editor)
       editor = atom.workspace.getActivePaneItem()
     if (!editor)
       return
-      
+
     gutterEnabled = atom.config.get('php-debug.GutterBreakpointToggle')
     if (!gutterEnabled)
       return
-      
+
     gutterPosition = atom.config.get('php-debug.GutterPosition')
     if gutterPosition == "Left"
       priority = -200
     else
       priority = 200
-      
+
     if (editor.gutterWithName('php-debug-gutter') != null)
       @gutter = editor.gutterWithName('php-debug-gutter')
       return
     else
       @gutter = editor?.gutterContainer.addGutter {name:'php-debug-gutter', priority: priority}
-    
+
     view = atom.views.getView editor
     domNode = atom.views.getView @gutter
     $(domNode).unbind 'click.phpDebug'
@@ -319,7 +319,7 @@ module.exports = PhpDebug =
       clickedScreenRow = view.component.screenPositionForMouseEvent(event).row
       clickedBufferRow  = editor.bufferRowForScreenRow(clickedScreenRow)+1
       @toggleBreakpoint clickedBufferRow
-      
+
     if @gutter
       for breakpoint in @GlobalContext.getBreakpoints()
         if breakpoint.getPath() == editor.getPath()
@@ -343,9 +343,9 @@ module.exports = PhpDebug =
           @getUnifiedView().setVisible(false)
           @statusView?.setActive(false)
           return
-    
+
       @createGutter()
-      
+
     else
       @getUnifiedView().setVisible(false)
       @statusView?.setActive(false)

--- a/lib/status/php-debug-status-view.coffee
+++ b/lib/status/php-debug-status-view.coffee
@@ -18,6 +18,3 @@ class PhpDebugStatusView extends View
       @element.className = 'php-debug-status-view active'
     else
       @element.className = 'php-debug-status-view'
-
-  destroy: ->
-    @.remove()

--- a/lib/status/php-debug-status-view.coffee
+++ b/lib/status/php-debug-status-view.coffee
@@ -18,3 +18,6 @@ class PhpDebugStatusView extends View
       @element.className = 'php-debug-status-view active'
     else
       @element.className = 'php-debug-status-view'
+
+  destroy: ->
+    @.remove()

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -120,6 +120,7 @@ class PhpDebugUnifiedView extends ScrollView
   destroy: =>
     if @GlobalContext.getCurrentDebugContext()
       @GlobalContext.getCurrentDebugContext().executeDetach()
+    @panel.destroy()
 
   isEqual: (other) ->
     other instanceof PhpDebugUnifiedView

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -62,7 +62,7 @@ class PhpDebugUnifiedView extends ScrollView
   getURI: -> @uri
 
   getTitle: -> "Debugging"
-  
+
 
 
   setConnected: (isConnected) =>

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -18,7 +18,8 @@ class PhpDebugUnifiedView extends ScrollView
           @button class: "btn octicon icon-steps inline-block-tight",            disabled: 'disabled', 'data-action':'step', "Step Over"
           @button class: "btn octicon icon-sign-in inline-block-tight",          disabled: 'disabled', 'data-action':'in', "Step In"
           @button class: "btn octicon icon-sign-out inline-block-tight",         disabled: 'disabled', 'data-action':'out', "Step Out"
-          @button class: "btn octicon icon-primitive-square inline-block-tight", disabled: 'disabled', 'data-action':'stop', "Stop"
+          @button class: "btn octicon icon-primitive-square inline-block-tight", disabled: 'disabled', 'data-action':'stop', "Abort"
+          @button class: "btn octicon icon-star inline-block-tight", disabled: 'disabled', 'data-action':'detach', "Finish"
           @span outlet: 'connectStatus'
         @div class: 'tabs-view', =>
           @div outlet: 'stackView', class:'php-debug-tab'
@@ -105,8 +106,10 @@ class PhpDebugUnifiedView extends ScrollView
           @GlobalContext.getCurrentDebugContext().continue "step_into"
         when 'out'
           @GlobalContext.getCurrentDebugContext().continue "step_out"
-        when 'stop'
+        when 'detach'
           @GlobalContext.getCurrentDebugContext().executeDetach()
+        when 'stop'
+          @GlobalContext.getCurrentDebugContext().executeStop()
 
         else
           console.error "unknown action"

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -1,10 +1,13 @@
-{Disposable} = require 'atom'
 {$, ScrollView} = require 'atom-space-pen-views'
+Disposable = require 'atom'
+Interact = require 'interact.js'
+
 PhpDebugContextView = require '../context/php-debug-context-view'
 PhpDebugStackView = require '../stack/php-debug-stack-view'
 PhpDebugWatchView = require '../watch/php-debug-watch-view'
 PhpDebugBreakpointView = require '../breakpoint/php-debug-breakpoint-view'
-Interact = require('interact.js')
+PhpDebugErrormessageView = require '../error/php-debug-errormessage-view'
+
 module.exports =
 class PhpDebugUnifiedView extends ScrollView
   @content: ->
@@ -22,6 +25,7 @@ class PhpDebugUnifiedView extends ScrollView
           @div outlet: 'contextView', class:'php-debug-tab'
           @div outlet: 'watchpointView', class:'php-debug-tab'
           @div outlet: 'breakpointView', class:'php-debug-tab'
+          @div outlet: 'errormessageView', class:'php-debug-tab'
 
   constructor: (params) ->
     super
@@ -88,6 +92,7 @@ class PhpDebugUnifiedView extends ScrollView
     @contextView.append(new PhpDebugContextView(context: params.context))
     @watchpointView.append(new PhpDebugWatchView(context: params.context))
     @breakpointView.append(new PhpDebugBreakpointView(context: params.context))
+    @errormessageView.append(new PhpDebugErrormessageView(context: params.context))
 
     @on 'click', '[data-action]', (e) =>
       action = e.target.getAttribute('data-action')

--- a/styles/php-debug.atom-text-editor.less
+++ b/styles/php-debug.atom-text-editor.less
@@ -14,7 +14,7 @@
 
   background-color: @background-color-info;
   color: white;
-  
+
 }
 
 .gutter>.line-numbers>.php-debug-breakpoint,

--- a/styles/php-debug.less
+++ b/styles/php-debug.less
@@ -125,3 +125,15 @@ atom-panel.modal .breakpoint-settings-view .setting-new atom-text-editor[mini] {
 .php-debug-watchpoints .watch-item {
   position:relative;
 }
+
+.php-debug-errormessage-view {
+  .fatal {
+    color: @text-color-error;
+  }
+  .warning {
+    color: @text-color-warning;
+  }
+  .notice {
+    color: @text-color-info;
+  }
+}


### PR DESCRIPTION
Hot package reloading didn't work, because some errors occurred in php-debug.deactivate.
I use atom-hot-package-loader. Reloading works nice now.
To reproduce, open php-debug panel and run
atom.packages.deactivatePackage('php-debug')
atom.packages.activatePackage('php-debug')
in the Developertools JS-Console.

I also created a error message pane in the table.

Also: this is my first PR ever! :)
