### PR TITLE
fix error on package deactivate/activate (hot-package-reloading)

### DIFF
--- a/lib/breakpoint/breakpoint-item-view.coffee
+++ b/lib/breakpoint/breakpoint-item-view.coffee
@@ -2,6 +2,7 @@
 
 module.exports =
 class BreakpointItemView extends View
+
   @content: =>
     @li class: 'meow', =>
       @div class: 'meow', =>

--- a/lib/breakpoint/breakpoint-list-view.coffee
+++ b/lib/breakpoint/breakpoint-list-view.coffee
@@ -1,13 +1,13 @@
 {$, View} = require 'atom-space-pen-views'
 BreakpointItemView = require './breakpoint-item-view'
-helpers        = require '../helpers'
+helpers = require '../helpers'
 
 module.exports =
 class BreakpointListView extends View
 
   @content: =>
-      @ul class: "breakpoint-list-view", =>
-        @div outlet: "breakpointItemList"
+    @ul class: "breakpoint-list-view", =>
+      @div outlet: "breakpointItemList"
 
   initialize: (breakpoints) ->
     @breakpointItemList.on 'mousedown', 'li', (e) =>

--- a/lib/breakpoint/breakpoint-settings-condition-view.coffee
+++ b/lib/breakpoint/breakpoint-settings-condition-view.coffee
@@ -3,6 +3,7 @@
 
 module.exports =
 class BreakpointSettingsConditionView extends View
+
   @content: (params) ->
     @div class: 'breakpoint-setting setting-condition setting-existing', =>
       @span class: 'setting-label', "Condition:"

--- a/lib/breakpoint/breakpoint-settings-view.coffee
+++ b/lib/breakpoint/breakpoint-settings-view.coffee
@@ -5,6 +5,7 @@ GlobalContext = require '../models/global-context'
 
 module.exports =
 class BreakpoinSettingsView extends View
+  
   @content: =>
     @div class: 'breakpoint-settings-view', =>
       @span click: 'close', class: 'atom-pair-exit-view close-icon'

--- a/lib/breakpoint/php-debug-breakpoint-view.coffee
+++ b/lib/breakpoint/php-debug-breakpoint-view.coffee
@@ -2,11 +2,11 @@
 {$, ScrollView} = require 'atom-space-pen-views'
 BreakpointView = require './breakpoint-view'
 GutterContainer = require './breakpoint-view'
-
 GlobalContext = require '../models/global-context'
 
 module.exports =
 class PhpDebugBreakpointView extends ScrollView
+
   @content: ->
     @div class: 'php-debug php-debug-breakpoint-view pane-item', tabindex: -1, =>
       @div class: "panel-heading", "Breakpoints"
@@ -25,6 +25,7 @@ class PhpDebugBreakpointView extends ScrollView
   getTitle: -> "Breakpoints"
 
   onDidChangeTitle: -> new Disposable ->
+
   onDidChangeModified: -> new Disposable ->
 
   isEqual: (other) ->
@@ -34,7 +35,6 @@ class PhpDebugBreakpointView extends ScrollView
     @GlobalContext = params.context
     @showBreakpoints()
     @GlobalContext.onBreakpointsChange @showBreakpoints
-
 
   showBreakpoints: =>
     if @breakpointViewList

--- a/lib/context/context-variable-list-view.coffee
+++ b/lib/context/context-variable-list-view.coffee
@@ -1,6 +1,6 @@
 {View} = require 'atom-space-pen-views'
 ContextVariableView = require './context-variable-view'
-helpers        = require '../helpers'
+helpers = require '../helpers'
 
 module.exports =
 class ContextVariableListView extends View
@@ -25,5 +25,3 @@ class ContextVariableListView extends View
     if @variables
       for variable in @variables
         @contextVariableList.append(new ContextVariableView({variable:variable, parent: path,openpaths:@openpaths}))
-
-    

--- a/lib/context/context-variable-scalar-view.coffee
+++ b/lib/context/context-variable-scalar-view.coffee
@@ -1,15 +1,10 @@
 {View} = require 'atom-space-pen-views'
-helpers        = require '../helpers'
+helpers = require '../helpers'
+
 module.exports =
 class ContextVariableScalarView extends View
+
   @content: (params) =>
     @div =>
       @span class: 'variable php', params.label
       @span class: 'type php', params.value
-
-  # initialize: ({@name, @value}) ->
-  #   @render()
-  #
-  # render: ->
-  #   @variableName.append(@name)
-  #   @variableValue.append(@value)

--- a/lib/context/context-variable-view.coffee
+++ b/lib/context/context-variable-view.coffee
@@ -1,9 +1,10 @@
 {View} = require 'atom-space-pen-views'
 ContextVariableScalarView = require "./context-variable-scalar-view"
-helpers        = require '../helpers'
+helpers = require '../helpers'
 
 module.exports =
 class ContextVariableView extends View
+
   @content: =>
     @li class: 'native-key-bindings', =>
       @div class: 'native-key-bindings', tabindex: -1, outlet: 'variableView'

--- a/lib/context/php-debug-context-view.coffee
+++ b/lib/context/php-debug-context-view.coffee
@@ -4,6 +4,7 @@ ContextView = require './context-view'
 
 module.exports =
 class PhpDebugContextView extends ScrollView
+
   @content: ->
     @div class: 'php-debug php-debug-context-view pane-item native-key-bindings', style: "overflow:auto;", tabindex: -1, =>
       @div class: "panel-heading", "Context"
@@ -24,7 +25,9 @@ class PhpDebugContextView extends ScrollView
     @GlobalContext.onSessionEnd () =>
       if @contextViewList
         @contextViewList.empty()
+
   onDidChangeTitle: -> new Disposable ->
+    
   onDidChangeModified: -> new Disposable ->
 
   isEqual: (other) ->

--- a/lib/engines/dbgp/dbgp-instance.coffee
+++ b/lib/engines/dbgp/dbgp-instance.coffee
@@ -2,13 +2,13 @@ parseString = require('xml2js').parseString
 Q = require 'q'
 {Emitter, Disposable} = require 'event-kit'
 helpers = require '../../helpers.coffee'
-
 DebugContext = require '../../models/debug-context'
 Watchpoint = require '../../models/watchpoint'
 Breakpoint = require '../../models/breakpoint'
 
 module.exports =
 class DbgpInstance extends DebugContext
+
   constructor: (params) ->
     super
     @socket = params.socket
@@ -30,8 +30,6 @@ class DbgpInstance extends DebugContext
 
   syncStack: (depth) ->
     options = {}
-    #if depth >= 0
-    #  options.d = depth;
     if depth < 0
       depth = 0
     return @executeCommand('stack_get', options).then (data) =>
@@ -84,7 +82,6 @@ class DbgpInstance extends DebugContext
     else
       console.warn "Could not find promise for transaction " + transactionId
 
-
   stuff: (data) =>
     @buffer = message = @parse(@buffer + data)
 
@@ -131,7 +128,6 @@ class DbgpInstance extends DebugContext
       return @sendAllBreakpoints()
     .then () =>
       return @executeRun()
-
 
   sendAllBreakpoints: =>
     breakpoints = @GlobalContext.getBreakpoints()
@@ -206,7 +202,6 @@ class DbgpInstance extends DebugContext
             messages = response["xdebug:message"]
             message = messages[0]
             thing = message.$
-            #console.dir data
             filepath = decodeURI(thing['filename']).replace("file:///", "")
 
             if not filepath.match(/^[a-zA-Z]:/)
@@ -284,7 +279,6 @@ class DbgpInstance extends DebugContext
     for watch in @GlobalContext.getWatchpoints()
       commands.push @evalWatchpoint(watch)
     return Q.all(commands)
-
 
   executeEval: (expression) ->
     return @command("eval", null, expression)

--- a/lib/engines/dbgp/dbgp.coffee
+++ b/lib/engines/dbgp/dbgp.coffee
@@ -1,13 +1,13 @@
 parseString = require('xml2js').parseString
 Q = require 'q'
 {Emitter, Disposable} = require 'event-kit'
-
 DebugContext = require '../../models/debug-context'
 Watchpoint = require '../../models/watchpoint'
 DbgpInstance = require './dbgp-instance'
 
 module.exports =
 class Dbgp
+
   constructor: (params) ->
     @emitter = new Emitter
     @buffer = ''
@@ -21,7 +21,6 @@ class Dbgp
     return @socket && @socket.readyState == 1
 
   listen: (options) ->
-
     @debugContext = new DebugContext
     net = require "net"
     buffer = ''
@@ -43,7 +42,7 @@ class Dbgp
         @close()
         @GlobalContext.notifySocketError()
         return false
-        
+
       @server?.listen @serverPort
       return true
     catch e
@@ -52,7 +51,6 @@ class Dbgp
       @close()
       @GlobalContext.notifySocketError()
       return false
-      # body...
 
   close: (options) ->
     unless !@socket

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -14,7 +14,7 @@ exports.escapeValue = (object) ->
   if (typeof object == "string")
     return "\"" + object.replace("\\","\\\\").replace("\"","\\\"") + "\""
   return object;
-  
+
 exports.escapeHtml = (string) ->
   entityMap = {
     "<": "&lt;"
@@ -94,5 +94,5 @@ exports.remotePathToLocal = (remotePath) ->
       if remotePath.indexOf(remote) == 0
         return remotePath.replace(remote, local)
         break
-    
+
   return remotePath.replace('file://','')

--- a/lib/models/breakpoint-marker.coffee
+++ b/lib/models/breakpoint-marker.coffee
@@ -1,33 +1,31 @@
-
-
 module.exports =
 class BreakpointMarker
+
   constructor: (@editor,@range,@gutter) ->
     @markers = {}
     enableGutters = atom.config.get('php-debug.GutterBreakpointToggle')
     if enableGutters && gutter
       gutterMarker = @editor.markBufferRange(@range, {invalidate: 'inside'})
       @markers.gutter = gutterMarker
-    
+
     lineMarker = @editor.markBufferRange(@range)
-    @markers.line = lineMarker 
-    
+    @markers.line = lineMarker
+
   decorate: ->
     item = document.createElement('span')
     item.className = "highlight php-debug-gutter php-debug-highlight"
 
     if @markers.gutter
       @gutter.decorateMarker(@markers.gutter, {class: 'php-debug-gutter-marker',item})
-    
+
     if @markers.line
       @editor.decorateMarker(@markers.line, {type: 'line-number', class: 'php-debug-breakpoint'})
-    
+
   destroy: ->
     for type,marker of @markers
       marker?.destroy()
-      
+
   getStartBufferPosition: ->
     for type,marker of @markers
       if marker
         return marker.getStartBufferPosition()
-    

--- a/lib/models/debug-context.coffee
+++ b/lib/models/debug-context.coffee
@@ -1,7 +1,6 @@
 helpers = require '../helpers.coffee'
 
 module.exports =
-
 class DebugContext
 
   constructor: () ->

--- a/lib/models/global-context.coffee
+++ b/lib/models/global-context.coffee
@@ -3,14 +3,15 @@ helpers = require '../helpers.coffee'
 
 module.exports =
 class GlobalContext
+
   atom.deserializers.add(this)
   # @version = '1a'
+
   constructor: ->
     @emitter = new Emitter
     @breakpoints = []
     @watchpoints = []
     @debugContexts = []
-
     @onSessionEnd () =>
       delete @debugContexts[0]
       @debugContexts = []
@@ -97,7 +98,6 @@ class GlobalContext
 
   clearContext: ->
 
-
   onBreakpointsChange: (callback) ->
     @emitter.on 'php-debug.breakpointsChange', callback
 
@@ -133,7 +133,7 @@ class GlobalContext
 
   notifySessionEnd: (data) ->
     @emitter.emit 'php-debug.sessionEnd', data
-    
+
   onSocketError: (callback) ->
     @emitter.on 'php-debug.socketError', callback
 

--- a/lib/models/watchpoint.coffee
+++ b/lib/models/watchpoint.coffee
@@ -1,7 +1,9 @@
 module.exports =
 class Watchpoint
+
   atom.deserializers.add(this)
   @version: '1b'
+
   constructor: (data) ->
     if (!data.expression)
       throw new Error("Invalid watchpoint")

--- a/lib/php-debug-panel-view.coffee
+++ b/lib/php-debug-panel-view.coffee
@@ -5,4 +5,4 @@ class PhpDebugPanel extends View
   @content: ->
     @div class: "php-debug panel", =>
       @div class: "panel-heading", "Node Debugger"
-      @div class: "panel-body padded" 
+      @div class: "panel-body padded"

--- a/lib/php-debug-panel-view.coffee
+++ b/lib/php-debug-panel-view.coffee
@@ -1,8 +1,0 @@
-{View} = require 'atom'
-
-module.exports =
-class PhpDebugPanel extends View
-  @content: ->
-    @div class: "php-debug panel", =>
-      @div class: "panel-heading", "Node Debugger"
-      @div class: "panel-body padded"

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -136,7 +136,7 @@ module.exports = PhpDebug =
 
     @GlobalContext.onStackChange (codepoint) =>
       @doCodePoint(codepoint)
-    
+
     @GlobalContext.onSocketError () =>
       @toggleDebugging()
 
@@ -167,19 +167,19 @@ module.exports = PhpDebug =
         for breakpoint in event.removed
           if breakpoint.getMarker()
             breakpoint.getMarker().destroy()
-            
+
     atom.workspace.observeTextEditors (editor) =>
       if (atom.config.get('php-debug.GutterBreakpointToggle'))
         @createGutter editor
-      else 
+      else
         for breakpoint in @GlobalContext.getBreakpoints()
           if breakpoint.getPath() == editor.getPath()
             marker = @addBreakpointMarker(breakpoint.getLine(), editor)
             breakpoint.setMarker(marker)
-            
+
     atom.config.observe "php-debug.GutterBreakpointToggle", (newValue) =>
-      @createGutters newValue    
-        
+      @createGutters newValue
+
     atom.config.observe "php-debug.GutterPosition", (newValue) =>
       @createGutters atom.config.get('php-debug.GutterBreakpointToggle'),true
 
@@ -237,7 +237,7 @@ module.exports = PhpDebug =
       filepath = point.getPath()
 
       filepath = helpers.remotePathToLocal(filepath)
-      
+
       atom.workspace.open(filepath,{searchAllPanes: true, activatePane:true}).then (editor) =>
         if @currentCodePointDecoration
           @currentCodePointDecoration.destroy()
@@ -253,12 +253,12 @@ module.exports = PhpDebug =
   addBreakpointMarker: (line, editor) ->
     gutter = editor.gutterWithName("php-debug-gutter")
     range = [[line-1, 0], [line-1, 0]]
-    
+
     marker = new BreakpointMarker(editor,range,gutter)
     marker.decorate()
 
     return marker
-    
+
 
   breakpointSettings: ->
     BreakpointSettingsView = require './breakpoint/breakpoint-settings-view'
@@ -273,7 +273,7 @@ module.exports = PhpDebug =
         break
     @settingsView = new BreakpointSettingsView({breakpoint:breakpoint,context:@GlobalContext})
     @settingsView.attach()
-  
+
   createGutters: (create,recreate) ->
     editors = atom.workspace.getTextEditors()
     for editor in editors
@@ -289,29 +289,29 @@ module.exports = PhpDebug =
               gutter?.destroy()
           if (editor?.gutterWithName('php-debug-gutter') == null)
             @createGutter(editor)
-  
+
   createGutter: (editor) ->
     if (!editor)
       editor = atom.workspace.getActivePaneItem()
     if (!editor)
       return
-      
+
     gutterEnabled = atom.config.get('php-debug.GutterBreakpointToggle')
     if (!gutterEnabled)
       return
-      
+
     gutterPosition = atom.config.get('php-debug.GutterPosition')
     if gutterPosition == "Left"
       priority = -200
     else
       priority = 200
-      
+
     if (editor.gutterWithName('php-debug-gutter') != null)
       @gutter = editor.gutterWithName('php-debug-gutter')
       return
     else
       @gutter = editor?.gutterContainer.addGutter {name:'php-debug-gutter', priority: priority}
-    
+
     view = atom.views.getView editor
     domNode = atom.views.getView @gutter
     $(domNode).unbind 'click.phpDebug'
@@ -319,7 +319,7 @@ module.exports = PhpDebug =
       clickedScreenRow = view.component.screenPositionForMouseEvent(event).row
       clickedBufferRow  = editor.bufferRowForScreenRow(clickedScreenRow)+1
       @toggleBreakpoint clickedBufferRow
-      
+
     if @gutter
       for breakpoint in @GlobalContext.getBreakpoints()
         if breakpoint.getPath() == editor.getPath()
@@ -343,9 +343,9 @@ module.exports = PhpDebug =
           @getUnifiedView().setVisible(false)
           @statusView?.setActive(false)
           return
-    
+
       @createGutter()
-      
+
     else
       @getUnifiedView().setVisible(false)
       @statusView?.setActive(false)

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -224,8 +224,7 @@ module.exports = PhpDebug =
 
   deactivate: ->
     @unifiedView?.setConnected(false)
-    @statusView?.destroy()
-    @statusView = null
+    @statusView?.remove()
     @unifiedView?.destroy()
     @subscriptions.dispose()
     @dbgp?.close()

--- a/lib/stack/php-debug-stack-view.coffee
+++ b/lib/stack/php-debug-stack-view.coffee
@@ -1,10 +1,11 @@
 {$, ScrollView} = require 'atom-space-pen-views'
-
 StackFrameView = require('./stack-frame-view')
 GlobalContext = require '../models/global-context'
 Codepoint = require '../models/codepoint'
+
 module.exports =
 class PhpDebugStackView extends ScrollView
+
   @content: ->
     @div class: 'php-debug php-debug-context-view pane-item native-key-bindings', style: "overflow:auto;", tabindex: -1, =>
       @div class: "panel-heading", "Stack"

--- a/lib/status/php-debug-status-view.coffee
+++ b/lib/status/php-debug-status-view.coffee
@@ -1,6 +1,8 @@
 {$, View} = require 'atom-space-pen-views'
+
 module.exports =
 class PhpDebugStatusView extends View
+
   @content: ->
     @div click: 'toggleDebugging', class: 'php-debug-status-view', =>
       @span class: 'icon icon-bug'

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -5,8 +5,10 @@ PhpDebugStackView = require '../stack/php-debug-stack-view'
 PhpDebugWatchView = require '../watch/php-debug-watch-view'
 PhpDebugBreakpointView = require '../breakpoint/php-debug-breakpoint-view'
 Interact = require('interact.js')
+
 module.exports =
 class PhpDebugUnifiedView extends ScrollView
+
   @content: ->
     @div class: 'php-debug', tabindex: -1, =>
       @div class: 'php-debug-unified-view', =>
@@ -62,8 +64,6 @@ class PhpDebugUnifiedView extends ScrollView
   getURI: -> @uri
 
   getTitle: -> "Debugging"
-  
-
 
   setConnected: (isConnected) =>
     @panel?.item?.style.height = @panel?.item?.clientHeight + 'px'

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -120,6 +120,7 @@ class PhpDebugUnifiedView extends ScrollView
   destroy: =>
     if @GlobalContext.getCurrentDebugContext()
       @GlobalContext.getCurrentDebugContext().executeDetach()
+    @panel.destroy()
 
   isEqual: (other) ->
     other instanceof PhpDebugUnifiedView

--- a/lib/watch/php-debug-watch-view.coffee
+++ b/lib/watch/php-debug-watch-view.coffee
@@ -5,8 +5,10 @@
 WatchView = require './watch-view'
 GlobalContext = require '../models/global-context'
 Watchpoint = require '../models/watchpoint'
+
 module.exports =
 class PhpDebugWatchView extends ScrollView
+
   @content: ->
     @div class: "panel", =>
       @div class: "panel-heading", "Watchpoints"
@@ -27,8 +29,8 @@ class PhpDebugWatchView extends ScrollView
   getTitle: -> "Watch"
 
   onDidChangeTitle: -> new Disposable ->
-  onDidChangeModified: -> new Disposable ->
 
+  onDidChangeModified: -> new Disposable ->
 
   initialize: (params) ->
     @GlobalContext = params.context

--- a/styles/php-debug.atom-text-editor.less
+++ b/styles/php-debug.atom-text-editor.less
@@ -11,10 +11,8 @@
 }
 // Styling Error Types
 .gutter .php-debug-gutter.highlight {
-
   background-color: @background-color-info;
   color: white;
-  
 }
 
 .gutter>.line-numbers>.php-debug-breakpoint,
@@ -30,7 +28,6 @@
 .debug-break-generic {
   background-color: fade(@background-color-success,25%) !important;
 }
-
 .debug-break-error {
   background-color: fade(@background-color-error,15%) !important;
 }


### PR DESCRIPTION
d5c3ec9 method @statusView?.destroy() doesn't exist, the resulting error prevents from package reloading
@unifiedView?.destroy() on the other hand does exist but should then call @panel.destroy() to actually remove the panel, otherwise we get one more new panel with each reload