### PR TITLE
Pathmap errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Put the following in your config.cson
     ]
   }
   ```
+Be sure to indent it under "*"
 
 ### Server Port ###
 This is the port that the atom client will listen on.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If everything worked correctly, you can now use the various buttons/commands to 
 
 # Settings
 
-Put the following in your config.cson
+Put the following in your config.cson from File -> Config...
 ```cson
 "php-debug":
   {


### PR DESCRIPTION
Check if a file exists on the remote server given the configured PatpMaps, also check for other errors that are not currently being handled. Test this change by breaking your PathMaps to see what happens

In order to do this I used the "source" command from https://xdebug.org/docs-dbgp.php

This change only presents errors as appropriate, and doesn't actually change the package's logic
