### PR TITLE
Console history

### DIFF
--- a/keymaps/php-debug.cson
+++ b/keymaps/php-debug.cson
@@ -34,3 +34,7 @@
   'alt-f6': 'php-debug:stepOver'
   'alt-f7': 'php-debug:stepIn'
   'alt-f8': 'php-debug:stepOut'
+
+'atom-workspace .php-debug-console atom-text-editor':
+  'alt-up': 'php-debug:navigatePreviousConsoleCommand'
+  'alt-down': 'php-debug:navigateNextConsoleCommand'

--- a/keymaps/php-debug.cson
+++ b/keymaps/php-debug.cson
@@ -38,3 +38,5 @@
 'atom-workspace .php-debug-console atom-text-editor':
   'alt-up': 'php-debug:navigatePreviousConsoleCommand'
   'alt-down': 'php-debug:navigateNextConsoleCommand'
+  'up': 'php-debug:navigatePreviousConsoleCommand'
+  'down': 'php-debug:navigateNextConsoleCommand'

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -157,6 +157,8 @@ module.exports = PhpDebug =
     @subscriptions.add atom.commands.add 'atom-workspace', 'php-debug:stepOut': => @stepOut()
     @subscriptions.add atom.commands.add 'atom-workspace', 'php-debug:clearAllBreakpoints': => @clearAllBreakpoints()
     @subscriptions.add atom.commands.add 'atom-workspace', 'php-debug:clearAllWatchpoints': => @clearAllWatchpoints()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'php-debug:navigatePreviousConsoleCommand': => @navigatePreviousConsoleCommand()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'php-debug:navigateNextConsoleCommand': => @navigateNextConsoleCommand()
     @subscriptions.add atom.workspace.addOpener (filePath) =>
       switch filePath
         when PhpDebugContextUri
@@ -480,3 +482,9 @@ module.exports = PhpDebug =
       marker = @addBreakpointMarker(line, editor)
       breakpoint.setMarker(marker)
       @GlobalContext.addBreakpoint breakpoint
+
+  navigatePreviousConsoleCommand: ->
+    @consoleView.prevCommand()
+
+  navigateNextConsoleCommand: ->
+    @consoleView.nextCommand()


### PR DESCRIPTION
Split from PR #220 by @cgalvarez 

**Console**

- User can now navigate through the last 20 commands entered with alt+up/alt+down (when focused on the input of the text editor inside the console panel). It's useful when you want to execute the same code multiple times or the last executed command contained an error.