### PR TITLE
cherry picked themable code to color variables list

### DIFF
--- a/lib/context/context-variable-list-view.coffee
+++ b/lib/context/context-variable-list-view.coffee
@@ -8,11 +8,24 @@ class ContextVariableListView extends View
   @content: (params) ->
     dataname = if params.name then params.name else ''
     dataname = if !!params.parent then params.parent + '.' + dataname else dataname
+    nameIsNumeric = /^\d+$/.test(params.name)
+    label = params.name
+    if !params.parent # root taxonomy (Locals, etc.)
+      labelClass = 'syntax--type'
+    else if params.parent.indexOf('.') == -1 # variable
+      labelClass = 'syntax--variable'
+    else # array key, object property
+      labelClass = "syntax--property #{if nameIsNumeric then 'syntax--constant syntax--numeric' else 'syntax--string'}"
+      label = '"' + params.name + '"'
+    valueClass = switch params.type
+      when 'array' then 'syntax--support syntax--function'
+      when 'object' then 'syntax--entity syntax--name syntax--type'
+      else ''
     @li class: "context-variable-list-view", =>
       @details 'data-name': dataname, =>
         @summary =>
-          @span class: 'variable php', params.name
-          @span class: 'type php', params.summary
+          @span class: "variable php syntax--php #{labelClass}", label
+          @span class: "type php syntax--php syntax--#{params.type} #{valueClass}", params.summary
         @ul outlet: "contextVariableList"
 
   initialize: ({@variables,@autoopen,@parent,@name,@openpaths}) ->
@@ -25,5 +38,3 @@ class ContextVariableListView extends View
     if @variables
       for variable in @variables
         @contextVariableList.append(new ContextVariableView({variable:variable, parent: path,openpaths:@openpaths}))
-
-    


### PR DESCRIPTION
Split from PR #220 by @cgalvarez 

**Context var list**

- Now bool values are printed correctly as true/false (previously was being printed as 1/0).
- Numeric keys are not enclosed between quotes anymore. This improves readability, since it's far easier to find any variable/key/property.
- Themeable, which improves readability too, since it's far easier to distinguish the type of a value based on its color:
  - The default is to inherit the styles from the current atom theme for the language-php package. This way, one uses the same color codes in the editor and the panels from this package. 
  - Now every label span is provided with new classes if it's a property of an object or a key of an array (otherwise it's a variable): syntax--property and syntax--numeric/syntax--string depending on the type.
  - Now every value span is provided with a class with the value type: syntax--array, syntax--bool, syntax--error, syntax--null, syntax--numeric, object, syntax--resource, syntax--string, or syntax--uninitialized.
  - Every span item uses the same syntax-php from the package language-php.
  - The top taxonomies (Locals/Superglobals/User defined constants) have the class syntax--type.