### PR TITLE
Array object format change

### DIFF
--- a/lib/context/context-view.coffee
+++ b/lib/context/context-view.coffee
@@ -20,4 +20,23 @@ class ContextView extends View
             openChildren = true
             break
 
+      cbDeepNaturalSort = (a,b) ->
+        aIsNumeric = /^\d+$/.test(a.name)
+        bIsNumeric = /^\d+$/.test(b.name)
+        # cannot exist two equal keys, so skip case of returning 0
+        if aIsNumeric && bIsNumeric # order numbers
+          return if (parseInt(a.name, 10) < parseInt(b.name, 10)) then -1 else 1
+        else if !aIsNumeric && !bIsNumeric # order strings
+          return if (a.name < b.name) then -1 else 1
+        else # string first (same behavior that PHP's `ksort`)
+          return if aIsNumeric then 1 else -1
+
+      fnWalkVar = (contextVar) ->
+        if Array.isArray(contextVar)
+          for item in contextVar
+            if Array.isArray(item.value)
+              fnWalkVar(item.value)
+          contextVar.sort(cbDeepNaturalSort)
+
+      fnWalkVar(@context.context.variables)
       @contextListView.append(new ContextVariableListView( {name: @context.name, summary: null, variables: @context.context.variables, autoopen: openChildren, openpaths:@autoopen, parent:null}))

--- a/lib/context/context-view.coffee
+++ b/lib/context/context-view.coffee
@@ -37,6 +37,6 @@ class ContextView extends View
             if Array.isArray(item.value)
               fnWalkVar(item.value)
           contextVar.sort(cbDeepNaturalSort)
-
-      fnWalkVar(@context.context.variables)
+      if (atom.config.get('php-debug.SortArray'))
+        fnWalkVar(@context.context.variables)
       @contextListView.append(new ContextVariableListView( {name: @context.name, summary: null, variables: @context.context.variables, autoopen: openChildren, openpaths:@autoopen, parent:null}))

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -135,6 +135,10 @@ module.exports = PhpDebug =
         UnknownError:
           type: 'boolean'
           default: true
+    SortArray:
+      title: "Sort Array/Object Elements Alphabetically"
+      type: 'boolean'
+      default: true
 
   activate: (state) ->
     if state
@@ -318,7 +322,7 @@ module.exports = PhpDebug =
             atom.focus()
         @GlobalContext.getCurrentDebugContext().syncCurrentContext(point.getStackDepth())
 
-        
+
   addBreakpointMarker: (line, editor) ->
     gutter = editor.gutterWithName("php-debug-gutter")
     range = [[line-1, 0], [line-1, 0]]


### PR DESCRIPTION
Split from PR #220 by @cgalvarez

**Context var list**

- Fixes the array length when the length property of a context variable is undefined. It happens to me with $GLOBALS['GLOBALS'], for example, which is shown as $GLOBALS['GLOBALS'] array[undefined], but its value is really Array[0].
- Sorted: now all variables, keys (in case of array) and properties (in case of objects) are sorted in a natural, alphabetical ascending order, following the same behavior as PHP function ksort() (string keys first, numeric ones then).

- Placed sort behind feature flag