### PR TITLE
fixes error when trying to config breakpoint with no breakpoint

### DIFF
--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -340,6 +340,7 @@ module.exports = PhpDebug =
       if bp.getPath() == path && bp.getLine() == line
         breakpoint = bp
         break
+    return if !breakpoint
     @settingsView = new BreakpointSettingsView({breakpoint:breakpoint,context:@GlobalContext})
     @settingsView.attach()
 


### PR DESCRIPTION
Split from PR #220 by @cgalvarez

**Editor**

- Fixes error when trying to change breakpoint configuration in a line with no breakpoint set.