### PR TITLE
cherry picked shorten array view TODO needs CSS for ':' and '=' to lo…

### DIFF
--- a/lib/engines/dbgp/dbgp-instance.coffee
+++ b/lib/engines/dbgp/dbgp-instance.coffee
@@ -443,10 +443,10 @@ class DbgpInstance extends DebugContext
       type: variable.$.type
     }
 
-    if variable.$.fullname?
-      datum.label = variable.$.fullname
-    else if variable.$.name?
+    if variable.$.name?
       datum.label = variable.$.name
+    else if variable.$.fullname?
+      datum.label = variable.$.fullname
 
     switch variable.$.type
       when "string"


### PR DESCRIPTION
Split from PR #220 by @cgalvarez

This needs the CSS that adds the ':' and '=' you mentioned to look good.

![missing css](https://user-images.githubusercontent.com/3241173/31586887-ac9d7744-b1a5-11e7-9eda-9bdb01654c4d.png)
