### PR TITLE
Allow toggling PathMap

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -64,36 +64,40 @@ exports.deserializeArray = (array) ->
   return ret
 
 exports.localPathToRemote = (localPath) ->
-  pathMaps = atom.config.get('php-debug.PathMaps')
-  for pathMap in pathMaps
-    remote = pathMap.substring(0,pathMap.indexOf(";"))
-    local = pathMap.substring(pathMap.indexOf(";")+1)
-    if localPath.indexOf(local) == 0
-      path = localPath.replace(local, remote)
-      if remote.indexOf('/') != null
-        # remote path appears to be a unix path, so replace any \'s with /'s'
-        path = path.replace(/\\/g, '/')
-      else if remote.indexOf('\\') != null
-        # remote path appears to be a windows path, so replace any /'s with \'s'
-        path = path.replace(/\//g, '\\')
-      return path.replace('file://','')
+  pathMapsEnabled = atom.config.get('php-debug.PathMapsEnabled')
+  if pathMapsEnabled
+    pathMaps = atom.config.get('php-debug.PathMaps')
+    for pathMap in pathMaps
+      remote = pathMap.substring(0,pathMap.indexOf(";"))
+      local = pathMap.substring(pathMap.indexOf(";")+1)
+      if localPath.indexOf(local) == 0
+        path = localPath.replace(local, remote)
+        if remote.indexOf('/') != null
+          # remote path appears to be a unix path, so replace any \'s with /'s'
+          path = path.replace(/\\/g, '/')
+        else if remote.indexOf('\\') != null
+          # remote path appears to be a windows path, so replace any /'s with \'s'
+          path = path.replace(/\//g, '\\')
+        return path.replace('file://','')
   return localPath.replace('file://','')
 
 exports.remotePathToLocal = (remotePath) ->
-  pathMaps = atom.config.get('php-debug.PathMaps')
   remotePath = decodeURI(remotePath)
-  for pathMap in pathMaps
-    remote = pathMap.substring(0,pathMap.indexOf(";"))
-    local = pathMap.substring(pathMap.indexOf(";")+1)
-    if remotePath.indexOf('/') != null && remotePath.indexOf('/') != 0
-      adjustedPath = '/' + remotePath
-      if adjustedPath.indexOf(remote) == 0
-        return adjustedPath.replace(remote, local)
-        break
-    else
-      if remotePath.indexOf(remote) == 0
-        return remotePath.replace(remote, local)
-        break
+  pathMapsEnabled = atom.config.get('php-debug.PathMapsEnabled')
+  if pathMapsEnabled
+    pathMaps = atom.config.get('php-debug.PathMaps')
+    for pathMap in pathMaps
+      remote = pathMap.substring(0,pathMap.indexOf(";"))
+      local = pathMap.substring(pathMap.indexOf(";")+1)
+      if remotePath.indexOf('/') != null && remotePath.indexOf('/') != 0
+        adjustedPath = '/' + remotePath
+        if adjustedPath.indexOf(remote) == 0
+          return adjustedPath.replace(remote, local)
+          break
+      else
+        if remotePath.indexOf(remote) == 0
+          return remotePath.replace(remote, local)
+          break
   adjustedPath = remotePath.replace('file://','')
   if (/^\/[a-zA-Z]:\//.test(adjustedPath))
     return adjustedPath.substr(1);

--- a/lib/php-debug.coffee
+++ b/lib/php-debug.coffee
@@ -94,6 +94,10 @@ module.exports = PhpDebug =
       items:
         type: 'string'
       description: "Paths in the format of remote;local (eg \"/var/www/project;C:\\projects\\mycode\")"
+    PathMapsEnabled:
+      title: 'Enable Path Map'
+      type: 'boolean'
+      default: true
     ServerAddress:
       type: 'string'
       default: '127.0.0.1'

--- a/lib/unified/php-debug-unified-view.coffee
+++ b/lib/unified/php-debug-unified-view.coffee
@@ -26,6 +26,10 @@ class PhpDebugUnifiedView extends ScrollView
               @span class: "btn-text", "Step Out"
             @button class: "btn btn-action octicon icon-primitive-square inline-block-tight", disabled: 'disabled', 'data-action':'stop', =>
               @span class: "btn-text",  "Stop"
+            @button
+              class: "btn btn-action btn-no-deactive mdi mdi-folder-multiple inline-block-tight action-path-map"
+              title: "Toggle Path Map"
+              'data-action': 'togglePathMap'
 
 
         @div class: 'tabs-wrapper', outlet:'tabsWrapper', =>
@@ -46,6 +50,11 @@ class PhpDebugUnifiedView extends ScrollView
       @find('button:not(.btn-no-deactive)').disable()
     @GlobalContext.onSessionEnd () =>
       @find('button:not(.btn-no-deactive)').disable()
+
+    @setEnablePathMaps atom.config.get('php-debug.PathMapsEnabled')
+    
+    atom.config.onDidChange 'php-debug.PathMapsEnabled', ({newValue, oldValue}) =>
+      @setEnablePathMaps newValue
 
     @find('.php-debug-tab .panel-heading').on 'click', (e) =>
       @handlePanelClick($(e.target))
@@ -166,6 +175,18 @@ class PhpDebugUnifiedView extends ScrollView
     @find('.php-debug').addClass('panel-mode-'+@panelMode)
     @resizer = @resizer.resizable({edges: @resizeType})
 
+  setEnablePathMaps: (value) ->
+    atom.config.set('php-debug.PathMapsEnabled', value)
+    if value
+      @find('.action-path-map').addClass('mdi-folder-multiple')
+      @find('.action-path-map').removeClass('mdi-folder-multiple-outline');
+    else
+      @find('.action-path-map').addClass('mdi-folder-multiple-outline');
+      @find('.action-path-map').removeClass('mdi-folder-multiple')
+
+  togglePathMap: ->
+    @setEnablePathMaps not atom.config.get('php-debug.PathMapsEnabled')
+
   setConnected: (isConnected) =>
     if (@panel?.item?.clientHeight > 0)
       @panel?.item?.style.height = @panel?.item?.clientHeight + 'px'
@@ -221,6 +242,8 @@ class PhpDebugUnifiedView extends ScrollView
           @GlobalContext.getCurrentDebugContext().continue "step_out"
         when 'stop'
           @GlobalContext.getCurrentDebugContext().executeDetach()
+        when 'togglePathMap'
+          @togglePathMap()
         when 'restore'
           @find('.php-debug-tab').css('display','block')
         when 'setmode-bottom'


### PR DESCRIPTION
This allows toggling on/off the PathMap.
I find it useful when debugging my code when running unit tests in local vs running on vagrant.
 
![image](https://user-images.githubusercontent.com/7089997/34404512-4df77f62-ebae-11e7-844d-947365d2f11b.png)

![image](https://user-images.githubusercontent.com/7089997/34404532-6c71e4e6-ebae-11e7-8127-9c5e7c3073ad.png)

If possible (and ideally) php-debug should be able to auto detect "where" the code is running and do that automatically but I did not find a way to do that.
I am open to suggestions and improvements to this PR.

(Mabe a "fallback" strategy could work as well)