### PR TITLE
Updated view property descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,21 +165,21 @@
               "title" : "Watches",
               "default" : true,
               "type" : "boolean",
-              "description" : "Show breakpoints panel",
+              "description" : "Show watches panel",
               "order": 2
             },
             "context" : {
               "title" : "Context",
               "default" : true,
               "type" : "boolean",
-              "description" : "Show breakpoints panel",
+              "description" : "Show context panel",
               "order": 3
             },
             "scope" : {
               "title" : "Scope",
               "default" : true,
               "type" : "boolean",
-              "description" : "Show breakpoints panel",
+              "description" : "Show scope panel",
               "order": 5
             }
           }


### PR DESCRIPTION
This fixes all the `View` options all having the same description `Show breakpoints panel`.

![screenshot 2018-05-04 22 26 17](https://user-images.githubusercontent.com/53531/39659984-3545dca2-4fea-11e8-9b12-8f8b0eb9aee8.png)
