### PR TITLE
Add wildcard breakpoint setting that triggers ALL exceptions/errors

### DIFF
--- a/lib/engines/dbgp/dbgp-instance.js
+++ b/lib/engines/dbgp/dbgp-instance.js
@@ -481,6 +481,9 @@ export default class DbgpInstance {
       if (atom.config.get('php-debug.exceptions.notice')) {
         commands.push(this.executeBreakpoint(service.createBreakpoint(null, null, {type: "exception", exception: 'Notice', stackDepth: -1})))
       }
+      if (atom.config.get('php-debug.exceptions.all')) {
+        commands.push(this.executeBreakpoint(service.createBreakpoint(null, null, {type: "exception", exception: '*', stackDepth: -1})))
+      }
 
       for (exception in atom.config.get('php-debug.exceptions.customExceptions')) {
         commands.push(this.executeBreakpoint(service.createBreakpoint(null, null, {type: "exception", exception: exception, stackDepth: -1})))

--- a/package.json
+++ b/package.json
@@ -262,6 +262,13 @@
           "type" : "boolean",
           "description" : "Break on notice messages",
           "order": 7
+        },
+        "all": {
+          "title": "All Exceptions/Errors",
+          "default": false,
+          "type": "boolean",
+          "description": "Break on all thrown errors and exceptions",
+          "order": 8
         }
       }
     },


### PR DESCRIPTION
Currently, there is no way to trigger a breakpoint on custom php Exceptions. You can't even trigger on predefined Exceptions such as `ErrorException`.

I think it would be a nice feature to allow us to add custom Exception Breakpoints in the settings. That way we could watch for certain custom Exceptions.

In the meanwhile, I added a wildcard `*` exception breakpoint that people can use.

Here is it's dbgp output: `breakpoint_set -i 18 -t "exception" -x "*"`.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/6479817/45179652-fc0e2e80-b1cd-11e8-86d5-d8d271d9788e.png)


