### PR TITLE
Convert filepath in stack trace to local

### DIFF
--- a/lib/engines/dbgp/dbgp-instance.js
+++ b/lib/engines/dbgp/dbgp-instance.js
@@ -68,7 +68,7 @@ export default class DbgpInstance {
             let csonFrame = {
               id:       frame.$.level,
               label:    frame.$.where,
-              filepath: frame.$.filename,
+              filepath: remotePathToLocal(decodeURI(frame.$.filename), this._pathMaps),
               level:    frame.$.level,
               line:     frame.$.lineno,
               active:   parseInt(frame.$.level,10) == depth ? true : false


### PR DESCRIPTION
Currently when the application executes `stack_get`, it simply takes the returned filenames and puts them into the stack trace. As a result, when you click on a stack trace to navigate to it, atom attempts to open a file whose path is relative to the remote server, not necessarily the local machine.

I simply used the existing `remotePathToLocal()` function to convert the filename to be relative to local!

Further improvements: It would be nice if we could display a "project relative" filepath in the stack trace instead of the FULL local filepath. Fully qualified local filepaths tend to be VERY long.