### PR TITLE
Fix empty stack trace/context variables

### DIFF
--- a/lib/engines/dbgp/dbgp-instance.js
+++ b/lib/engines/dbgp/dbgp-instance.js
@@ -226,6 +226,11 @@ export default class DbgpInstance {
   }
 
   parseXml(message) {
+    // strip illegal null bytes in anonymous class names
+    // so xml can be parsed correctly
+    // see https://github.com/gwomacks/php-debug/issues/336
+    message = message.replace(/@anonymous&#0;/g, '@anonymous#')
+
     let o = parseString(message, (err, result) => {
       if (err) {
         console.error(err)


### PR DESCRIPTION
This is a shot at fixing #336.

Problem:
* anonymous classes in PHP contain a `null byte` in their class names
* `xdebug` encodes this `null byte` in its XML messages - producing actually invalid XML
* `xml2js` / `sax` is unable to parse this XML
* as a result the stack trace and context panels can not be updated

For more details see https://github.com/gwomacks/php-debug/issues/336#issuecomment-1221543795.

Solution: replace all `null byte` entities in the XML string before passing it to `xml2js`